### PR TITLE
Fix subcommands version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           name: Run tests
           command: yarn test --coverage  --ci --reporters=default --reporters=jest-junit --runInBand
           environment:
-            JEST_JUNIT_OUTPUT_DIR: "test-results/jest"
+            JEST_JUNIT_OUTPUT_DIR: 'test-results/jest'
 
       - run: yarn pack -f clio-ts.tgz
 

--- a/docs/parsers/subcommands.md
+++ b/docs/parsers/subcommands.md
@@ -4,17 +4,21 @@ This is yet another combinator, which takes a couple of [`command`](./command.md
 
 ### Config
 
-* `name` (required): A name for the container
-* `version`: The container version
-* `cmds`: An object where the keys are the names of the subcommands to use, and the values are [`command`](./command.md) instances. You can also provide `subcommands` instances to nest a nested subcommand!
+- `name` (required): A name for the container
+- `version`: The container version
+- `cmds`: An object where the keys are the names of the subcommands to use, and the values are [`command`](./command.md) instances. You can also provide `subcommands` instances to nest a nested subcommand!
 
 ### Usage
 
 ```ts
 import { command, subcommands, run } from 'cmd-ts';
 
-const cmd1 = command({ /* ... */ });
-const cmd2 = command({ /* ... */ });
+const cmd1 = command({
+  /* ... */
+});
+const cmd2 = command({
+  /* ... */
+});
 
 const subcmd1 = subcommands({
   name: 'my subcmd1',
@@ -23,7 +27,7 @@ const subcmd1 = subcommands({
 
 const nestingSubcommands = subcommands({
   name: 'nesting subcommands',
-  cmds: { subcmd1 }
+  cmds: { subcmd1 },
 });
 
 run(nestingSubcommands, process.argv.slice(2));

--- a/example/app.ts
+++ b/example/app.ts
@@ -148,6 +148,7 @@ const withSubcommands = subcommands({
   },
   name: 'subcmds',
   description: 'An awesome subcommand app!',
+  version: '1.0.0',
 });
 
 const cli = binary(withSubcommands);

--- a/example/app.ts
+++ b/example/app.ts
@@ -95,7 +95,7 @@ const Name = extendType(string, {
     if (s.length === 0) {
       throw new Error('name cannot be empty');
     } else if (s === 'Bon Jovi') {
-      throw new Error(`Woah, we're half way there\nWoah! living on a prayer!`)
+      throw new Error(`Woah, we're half way there\nWoah! living on a prayer!`);
     } else if (s.charAt(0).toUpperCase() !== s.charAt(0)) {
       throw new Error('name must be capitalized');
     } else {

--- a/example/app.ts
+++ b/example/app.ts
@@ -20,6 +20,7 @@ import {
 } from '../src';
 
 const complex = command({
+  version: '6.6.6-alpha',
   args: {
     pos1: positional({
       displayName: 'pos1',

--- a/src/command.ts
+++ b/src/command.ts
@@ -17,7 +17,7 @@ import {
 } from './helpdoc';
 import { padNoAnsi, entries, groupBy, flatMap } from './utils';
 import { Runner } from './runner';
-import { circuitbreaker, handleCircuitBreaker } from './circuitbreaker';
+import { createCircuitBreaker, handleCircuitBreaker } from './circuitbreaker';
 import * as Result from './Result';
 
 type ArgTypes = Record<string, ArgParser<any> & Partial<ProvidesHelp>>;
@@ -57,6 +57,7 @@ export function command<
   Runner<Output<Arguments>, ReturnType<Handler>> &
   Partial<Versioned & Descriptive & Aliased> {
   const argEntries = entries(config.args);
+  const circuitbreaker = createCircuitBreaker(!!config.version);
 
   return {
     name: config.name,

--- a/src/subcommands.ts
+++ b/src/subcommands.ts
@@ -8,9 +8,9 @@ import {
 import { positional } from './positional';
 import { From } from './from';
 import { Runner } from './runner';
-import { Aliased, Named, Descriptive } from './helpdoc';
+import { Aliased, Named, Descriptive, Versioned } from './helpdoc';
 import chalk from 'chalk';
-import { circuitbreaker, handleCircuitBreaker } from './circuitbreaker';
+import { createCircuitBreaker, handleCircuitBreaker } from './circuitbreaker';
 import * as Result from './Result';
 
 type Output<
@@ -43,8 +43,9 @@ export function subcommands<
   description?: string;
 }): ArgParser<Output<Commands>> &
   Named &
-  Partial<Descriptive> &
+  Partial<Descriptive & Versioned> &
   Runner<Output<Commands>, RunnerOutput<Commands>> {
+  const circuitbreaker = createCircuitBreaker(!!config.version);
   const type: From<string, keyof Commands> = {
     async from(str) {
       const cmd = Object.entries(config.cmds)
@@ -69,6 +70,7 @@ export function subcommands<
   });
 
   return {
+    version: config.version,
     description: config.description,
     name: config.name,
     handler: value => {

--- a/test/__snapshots__/ui.test.ts.snap
+++ b/test/__snapshots__/ui.test.ts.snap
@@ -116,6 +116,8 @@ Along the following error:
 [31m[1mhint: [22m[39mfor more information, try '[33msubcmds greet --help[39m'"
 `;
 
+exports[`subcommands show their version 1`] = `"1.0.0"`;
+
 exports[`too many arguments 1`] = `
 "[31m[1merror: [22m[39mfound [33m1[39m error
 

--- a/test/__snapshots__/ui.test.ts.snap
+++ b/test/__snapshots__/ui.test.ts.snap
@@ -38,7 +38,7 @@ exports[`failures in defaultValue 1`] = `
 `;
 
 exports[`help for complex command 1`] = `
-"[1msubcmds complex[22m
+"[1msubcmds complex[22m [2m6.6.6-alpha[22m
 [2m> [22mJust prints the arguments
 
 ARGUMENTS:
@@ -65,8 +65,7 @@ ARGUMENTS:
   <stream> - A file path or a URL to make a GET request to
 
 FLAGS:
-  --help, -h    - show help
-  --version, -v - print the version"
+  --help, -h - show help"
 `;
 
 exports[`help for composed subcommands 1`] = `

--- a/test/ui.test.ts
+++ b/test/ui.test.ts
@@ -71,6 +71,12 @@ test('asynchronous type conversion works for success', async () => {
   expect(result.exitCode).toBe(0);
 });
 
+test('subcommands show their version', async () => {
+  const result = await runApp1(['--version']);
+  expect(result.all).toMatchSnapshot();
+  expect(result.exitCode).toBe(0);
+});
+
 test('failures in defaultValue', async () => {
   const result = await runApp2([]);
   expect(result.all).toMatchSnapshot();


### PR DESCRIPTION
Along with making circuitbreaker only provide `--version` when the command itself is versioned