### PR TITLE
Show subcommands name in hotpath

### DIFF
--- a/example/app3.ts
+++ b/example/app3.ts
@@ -1,0 +1,20 @@
+import { subcommands, command, option, string, run } from '../src';
+
+const sub1 = command({
+  name: 'sub1',
+  args: {
+    name: option({ type: string, long: 'name' }),
+  },
+  handler: ({ name }) => {
+    console.log({ name });
+  },
+});
+
+const nested = subcommands({
+  name: 'subcmds',
+  cmds: {
+    sub1,
+  },
+});
+
+run(nested, process.argv.slice(2));

--- a/src/subcommands.ts
+++ b/src/subcommands.ts
@@ -119,6 +119,9 @@ export function subcommands<
     async parse(
       context: ParseContext
     ): Promise<ParsingResult<Output<Commands>>> {
+      if (context.hotPath?.length === 0) {
+        context.hotPath.push(config.name);
+      }
       const parsed = await subcommand.parse(context);
 
       if (Result.isErr(parsed)) {
@@ -147,6 +150,10 @@ export function subcommands<
       });
     },
     async run(context): Promise<ParsingResult<RunnerOutput<Commands>>> {
+      if (context.hotPath?.length === 0) {
+        context.hotPath.push(config.name);
+      }
+
       const parsedSubcommand = await subcommand.parse(context);
 
       if (Result.isErr(parsedSubcommand)) {

--- a/test/__snapshots__/ui.test.ts.snap
+++ b/test/__snapshots__/ui.test.ts.snap
@@ -118,6 +118,16 @@ Along the following error:
 
 exports[`subcommands show their version 1`] = `"1.0.0"`;
 
+exports[`subcommands with process.argv.slice(2) 1`] = `
+"[1msubcmds[3m <subcommand>[23m[22m
+
+where [3m<subcommand>[23m can be one of:
+
+[2m- [22msub1
+
+[2mFor more help, try running \`[33msubcmds <subcommand> --help[39m\`[22m"
+`;
+
 exports[`too many arguments 1`] = `
 "[31m[1merror: [22m[39mfound [33m1[39m error
 

--- a/test/ui.test.ts
+++ b/test/ui.test.ts
@@ -83,8 +83,15 @@ test('failures in defaultValue', async () => {
   expect(result.exitCode).toBe(1);
 });
 
+test('subcommands with process.argv.slice(2)', async () => {
+  const result = await runApp3(['--help']);
+  expect(result.all).toMatchSnapshot();
+  expect(result.exitCode).toBe(1);
+})
+
 const runApp1 = app(path.join(__dirname, '../example/app.ts'));
 const runApp2 = app(path.join(__dirname, '../example/app2.ts'));
+const runApp3 = app(path.join(__dirname, '../example/app3.ts'));
 
 function app(
   scriptPath: string


### PR DESCRIPTION
So it won't be necessary to use `binary`