### PR TITLE
Update "flag" link

### DIFF
--- a/docs/included_types.md
+++ b/docs/included_types.md
@@ -6,7 +6,7 @@ A simple `string => string` type. Useful for [`option`](./parsers/options.md) an
 
 ### `boolean`
 
-A simple `boolean => boolean` type. Useful for [`flag`](./parsers/options.md)
+A simple `boolean => boolean` type. Useful for [`flag`](./parsers/flags.md)
 
 ### `number`
 


### PR DESCRIPTION
Seems more logical that `flag` will link to the [flags page](https://cmd-ts.hagever.com/parsers/flags.html).