### PR TITLE
Add "array" custom type

### DIFF
--- a/docs/included_types.md
+++ b/docs/included_types.md
@@ -16,6 +16,10 @@ A `string => number` type. Checks that the input is indeed a number or fails wit
 
 Takes a type and makes it nullable by providing a default value of `undefined`
 
+### `array(type)`
+
+Takes a type and turns it into an array of type, useful for [`multioption`](./parsers/options.md) and [`multiflag`](./parsers/flags.md).
+
 ### `union([types])`
 
 Tries to decode the types provided until it succeeds, or throws all the errors combined. There's an optional configuration to this function:

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,3 +53,18 @@ export function optional<T extends Type<any, any>>(
     },
   };
 }
+
+/**
+ * Transforms any type into an array, useful for `multioption` and `multiflag`.
+ */
+
+export function array<T extends Type<any, any>>(
+  t: T
+): Type<InputOf<T>[], OutputOf<T>[]> {
+  return {
+    ...t,
+    async from(inputs: InputOf<T>[]): Promise<OutputOf<T>[]> {
+      return Promise.all(inputs.map((input) => t.from(input)));
+    },
+  };
+}


### PR DESCRIPTION
Multiflag and multioption types must have an input array, which requires duplicating normal types to handle array.

I reckon that most of the times, just wrapping an existing type to receive and return itself as an array will be what is needed, therefore, I am suggesting implementing the array type, allowing the reuse of singular types as array types without hassle:

```js
multioption({ type: array(string), long: 'foo', short: 'f' })
```
