### PR TITLE
Allow negative numbers in options

### DIFF
--- a/example/negative-numbers.ts
+++ b/example/negative-numbers.ts
@@ -1,0 +1,23 @@
+import { binary, command, run, number, option } from '../src';
+
+export function createCmd() {
+  const cmd = command({
+    name: 'test',
+    args: {
+      number: option({
+        long: 'number',
+        type: number,
+      }),
+    },
+    async handler(args) {
+      console.log({ args });
+    },
+  });
+
+  return cmd;
+}
+
+if (require.main === module) {
+  const cmd = createCmd();
+  run(binary(cmd), process.argv);
+}

--- a/src/argparser.ts
+++ b/src/argparser.ts
@@ -30,6 +30,19 @@ export type ParseContext = {
 
 export type ParsingResult<Into> = Result<FailedParse, Into>;
 
+/**
+ * A weird thing about command line interfaces is that they are not consistent without some context.
+ * Consider the following argument list: `my-app --server start`
+ *
+ * Should we parse it as `[positional my-app] [option --server start]`
+ * or should we parse it as `[positional my-app] [flag --server] [positional start]`?
+ *
+ * The answer is — it depends. A good command line utility has the context to know which key is a flag
+ * and which is an option that can take a value. We aim to be a good command line utility library, so
+ * we need to have the ability to provide this context.
+ *
+ * This is the small object that has this context.
+ */
 export type RegisterOptions = {
   forceFlagLongNames: Set<string>;
   forceFlagShortNames: Set<string>;

--- a/src/argparser.ts
+++ b/src/argparser.ts
@@ -33,6 +33,8 @@ export type ParsingResult<Into> = Result<FailedParse, Into>;
 export type RegisterOptions = {
   forceFlagLongNames: Set<string>;
   forceFlagShortNames: Set<string>;
+  forceOptionLongNames: Set<string>;
+  forceOptionShortNames: Set<string>;
 };
 
 export type Register = {

--- a/src/multioption.ts
+++ b/src/multioption.ts
@@ -38,7 +38,12 @@ export function multioption<Decoder extends Type<string[], any>>(
         },
       ];
     },
-    register(_opts) {},
+    register(opts) {
+      opts.forceOptionLongNames.add(config.long);
+      if (config.short) {
+        opts.forceOptionShortNames.add(config.short);
+      }
+    },
     async parse({
       nodes,
       visitedNodes,
@@ -46,7 +51,7 @@ export function multioption<Decoder extends Type<string[], any>>(
       const options = findOption(nodes, {
         longNames: [config.long],
         shortNames: config.short ? [config.short] : [],
-      }).filter(x => !visitedNodes.has(x));
+      }).filter((x) => !visitedNodes.has(x));
 
       for (const option of options) {
         visitedNodes.add(option);

--- a/src/option.ts
+++ b/src/option.ts
@@ -74,7 +74,12 @@ function fullOption<Decoder extends Type<string, any>>(
         },
       ];
     },
-    register(_opts) {},
+    register(opts) {
+      opts.forceOptionLongNames.add(config.long);
+      if (config.short) {
+        opts.forceOptionShortNames.add(config.short);
+      }
+    },
     async parse({
       nodes,
       visitedNodes,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -38,18 +38,24 @@ export async function runSafely<R extends Runner<any, any>>(
   ap: R,
   strings: string[]
 ): Promise<Result<Exit, Into<R>>> {
+  const longFlagKeys = new Set<string>();
+  const shortFlagKeys = new Set<string>();
   const longOptionKeys = new Set<string>();
   const shortOptionKeys = new Set<string>();
   const hotPath: string[] = [];
   ap.register({
-    forceFlagShortNames: shortOptionKeys,
-    forceFlagLongNames: longOptionKeys,
+    forceFlagShortNames: shortFlagKeys,
+    forceFlagLongNames: longFlagKeys,
+    forceOptionShortNames: shortOptionKeys,
+    forceOptionLongNames: longOptionKeys,
   });
 
   const tokens = tokenize(strings);
   const nodes = parse(tokens, {
-    longFlagKeys: longOptionKeys,
-    shortFlagKeys: shortOptionKeys,
+    longFlagKeys,
+    shortFlagKeys,
+    longOptionKeys,
+    shortOptionKeys,
   });
 
   try {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -43,20 +43,17 @@ export async function runSafely<R extends Runner<any, any>>(
   const longOptionKeys = new Set<string>();
   const shortOptionKeys = new Set<string>();
   const hotPath: string[] = [];
-  ap.register({
+  const registerContext = {
     forceFlagShortNames: shortFlagKeys,
     forceFlagLongNames: longFlagKeys,
     forceOptionShortNames: shortOptionKeys,
     forceOptionLongNames: longOptionKeys,
-  });
+  };
+
+  ap.register(registerContext);
 
   const tokens = tokenize(strings);
-  const nodes = parse(tokens, {
-    longFlagKeys,
-    shortFlagKeys,
-    longOptionKeys,
-    shortOptionKeys,
-  });
+  const nodes = parse(tokens, registerContext);
 
   try {
     const result = await ap.run({ nodes, visitedNodes: new Set(), hotPath });

--- a/test/createRegisterOptions.ts
+++ b/test/createRegisterOptions.ts
@@ -1,0 +1,10 @@
+import type { RegisterOptions } from '../src/argparser';
+
+export function createRegisterOptions(): RegisterOptions {
+  return {
+    forceFlagLongNames: new Set(),
+    forceFlagShortNames: new Set(),
+    forceOptionLongNames: new Set(),
+    forceOptionShortNames: new Set(),
+  };
+}

--- a/test/errorBox.test.ts
+++ b/test/errorBox.test.ts
@@ -5,15 +5,13 @@ import { errorBox } from '../src/errorBox';
 import { option } from '../src/option';
 import { number } from './test-types';
 import * as Result from '../src/Result';
+import { createRegisterOptions } from './createRegisterOptions';
 
 test('works for multiple nodes', async () => {
   const argv = `hello world --some arg --flag --some another --flag --this-is=option -abcde=f -abcde`;
 
   const tokens = tokenize(argv.split(' '));
-  const tree = parse(tokens, {
-    longFlagKeys: new Set(),
-    shortFlagKeys: new Set(),
-  });
+  const tree = parse(tokens, createRegisterOptions());
 
   const opt = option({
     type: number,
@@ -37,10 +35,7 @@ test('works for a short flag', async () => {
   const argv = `hello world -fn not_a_number hey`;
 
   const tokens = tokenize(argv.split(' '));
-  const tree = parse(tokens, {
-    longFlagKeys: new Set(),
-    shortFlagKeys: new Set(),
-  });
+  const tree = parse(tokens, createRegisterOptions());
 
   const opt = option({
     type: number,
@@ -65,10 +60,7 @@ test('works for a single node', async () => {
   const argv = `hello world --flag --some not_a_number --flag --this-is=option -abcde=f -abcde`;
 
   const tokens = tokenize(argv.split(' '));
-  const tree = parse(tokens, {
-    longFlagKeys: new Set(),
-    shortFlagKeys: new Set(),
-  });
+  const tree = parse(tokens, createRegisterOptions());
 
   const opt = option({
     type: number,
@@ -92,10 +84,7 @@ test('works when no nodes', async () => {
   const argv = `hello world --flag --flag --this-is=option -abcde=f -abcde`;
 
   const tokens = tokenize(argv.split(' '));
-  const tree = parse(tokens, {
-    longFlagKeys: new Set(),
-    shortFlagKeys: new Set(),
-  });
+  const tree = parse(tokens, createRegisterOptions());
 
   const opt = option({
     type: number,

--- a/test/flag.test.ts
+++ b/test/flag.test.ts
@@ -3,25 +3,19 @@ import { tokenize } from '../src/newparser/tokenizer';
 import { parse } from '../src/newparser/parser';
 import { boolean } from '../src/types';
 import * as Result from '../src/Result';
+import { createRegisterOptions } from './createRegisterOptions';
 
 test('fails on incompatible value', async () => {
   const argv = `--hello=world`;
   const tokens = tokenize(argv.split(' '));
-  const shortOptionKeys = new Set<string>();
-  const longOptionKeys = new Set<string>();
   const argparser = flag({
     type: boolean,
     long: 'hello',
     description: 'description',
   });
-  argparser.register({
-    forceFlagShortNames: shortOptionKeys,
-    forceFlagLongNames: longOptionKeys,
-  });
-  const nodes = parse(tokens, {
-    shortFlagKeys: shortOptionKeys,
-    longFlagKeys: longOptionKeys,
-  });
+  const registerOptions = createRegisterOptions();
+  argparser.register(registerOptions);
+  const nodes = parse(tokens, registerOptions);
 
   const result = argparser.parse({
     nodes,
@@ -44,21 +38,14 @@ test('fails on incompatible value', async () => {
 test('defaults to false', async () => {
   const argv = ``;
   const tokens = tokenize(argv.split(' '));
-  const shortOptionKeys = new Set<string>();
-  const longOptionKeys = new Set<string>();
   const argparser = flag({
     type: boolean,
     long: 'hello',
     description: 'description',
   });
-  argparser.register({
-    forceFlagShortNames: shortOptionKeys,
-    forceFlagLongNames: longOptionKeys,
-  });
-  const nodes = parse(tokens, {
-    shortFlagKeys: shortOptionKeys,
-    longFlagKeys: longOptionKeys,
-  });
+  const registerOptions = createRegisterOptions();
+  argparser.register(registerOptions);
+  const nodes = parse(tokens, registerOptions);
 
   const result = argparser.parse({
     nodes,
@@ -71,22 +58,15 @@ test('defaults to false', async () => {
 test('allows short arguments', async () => {
   const argv = `-abc`;
   const tokens = tokenize(argv.split(' '));
-  const shortOptionKeys = new Set<string>();
-  const longOptionKeys = new Set<string>();
   const argparser = flag({
     type: boolean,
     long: 'hello',
     short: 'b',
     description: 'description',
   });
-  argparser.register({
-    forceFlagShortNames: shortOptionKeys,
-    forceFlagLongNames: longOptionKeys,
-  });
-  const nodes = parse(tokens, {
-    shortFlagKeys: shortOptionKeys,
-    longFlagKeys: longOptionKeys,
-  });
+  const registerOptions = createRegisterOptions();
+  argparser.register(registerOptions);
+  const nodes = parse(tokens, registerOptions);
 
   const result = argparser.parse({
     nodes,

--- a/test/negative-numbers.test.ts
+++ b/test/negative-numbers.test.ts
@@ -1,0 +1,18 @@
+import { createCmd } from '../example/negative-numbers';
+import { runSafely } from '../src';
+
+test('negative numbers', async () => {
+  const result = await new Promise<number>(async (resolve, reject) => {
+    const cmd = createCmd();
+    cmd.handler = async ({ number }) => {
+      resolve(number);
+    };
+
+    const runResult = await runSafely(cmd, ['--number', '-10']);
+    if (runResult._tag === 'error') {
+      reject(runResult.error);
+    }
+  });
+
+  expect(result).toEqual(-10);
+});

--- a/test/newparser/findOption.test.ts
+++ b/test/newparser/findOption.test.ts
@@ -1,14 +1,12 @@
 import { tokenize } from '../../src/newparser/tokenizer';
 import { parse } from '../../src/newparser/parser';
 import { findOption } from '../../src/newparser/findOption';
+import { createRegisterOptions } from '../createRegisterOptions';
 
 test('finds options', () => {
   const argv = `hello world --some arg --flag --this-is=option -abcde=f -abcde`;
   const tokens = tokenize(argv.split(' '));
-  const nodes = parse(tokens, {
-    longFlagKeys: new Set(),
-    shortFlagKeys: new Set(),
-  });
+  const nodes = parse(tokens, createRegisterOptions());
 
   const options = findOption(nodes, { longNames: ['some'], shortNames: ['c'] });
 

--- a/test/newparser/parser.test.ts
+++ b/test/newparser/parser.test.ts
@@ -1,12 +1,10 @@
 import { tokenize } from '../../src/newparser/tokenizer';
 import { parse } from '../../src/newparser/parser';
+import { createRegisterOptions } from '../createRegisterOptions';
 
 test('dash in the middle of a word', () => {
   const tokens = tokenize(['hello', 'world', 'you-know', 'my', 'friend']);
-  const tree = parse(tokens, {
-    longFlagKeys: new Set(),
-    shortFlagKeys: new Set(),
-  });
+  const tree = parse(tokens, createRegisterOptions());
   expect(tree).toMatchInlineSnapshot(`
     Array [
       Object {
@@ -43,10 +41,7 @@ test('welp', () => {
     ' '
   );
   const tokens = tokenize(argv);
-  const tree = parse(tokens, {
-    longFlagKeys: new Set(),
-    shortFlagKeys: new Set(),
-  });
+  const tree = parse(tokens, createRegisterOptions());
   expect(tree).toMatchInlineSnapshot(`
     Array [
       Object {

--- a/test/restPositionals.test.ts
+++ b/test/restPositionals.test.ts
@@ -3,14 +3,12 @@ import { tokenize } from '../src/newparser/tokenizer';
 import { parse, AstNode } from '../src/newparser/parser';
 import { number } from './test-types';
 import * as Result from '../src/Result';
+import { createRegisterOptions } from './createRegisterOptions';
 
 test('fails on specific positional', async () => {
   const argv = `10 20 --mamma mia hello 40`;
   const tokens = tokenize(argv.split(' '));
-  const nodes = parse(tokens, {
-    shortFlagKeys: new Set(),
-    longFlagKeys: new Set(),
-  });
+  const nodes = parse(tokens, createRegisterOptions());
   const argparser = restPositionals({
     type: number,
   });
@@ -21,7 +19,7 @@ test('fails on specific positional', async () => {
     Result.err({
       errors: [
         {
-          nodes: nodes.filter(x => x.raw === 'hello'),
+          nodes: nodes.filter((x) => x.raw === 'hello'),
           message: 'Not a number',
         },
       ],
@@ -32,16 +30,13 @@ test('fails on specific positional', async () => {
 test('succeeds when all unused positional decode successfuly', async () => {
   const argv = `10 20 --mamma mia hello 40`;
   const tokens = tokenize(argv.split(' '));
-  const nodes = parse(tokens, {
-    shortFlagKeys: new Set(),
-    longFlagKeys: new Set(),
-  });
+  const nodes = parse(tokens, createRegisterOptions());
   const argparser = restPositionals({
     type: number,
   });
 
   const visitedNodes = new Set<AstNode>();
-  const alreadyUsedNode = nodes.find(x => x.raw === 'hello');
+  const alreadyUsedNode = nodes.find((x) => x.raw === 'hello');
   if (!alreadyUsedNode) {
     throw new Error('Node `hello` not found. please rewrite the find function');
   }

--- a/test/subcommands.test.ts
+++ b/test/subcommands.test.ts
@@ -7,6 +7,7 @@ import { command } from '../src/command';
 import { subcommands } from '../src/subcommands';
 import { string, boolean } from './test-types';
 import * as Result from '../src/Result';
+import { createRegisterOptions } from './createRegisterOptions';
 
 const logMock = jest.fn();
 
@@ -17,7 +18,7 @@ const greeter = command({
     exclaim: flag({ type: boolean, long: 'exclaim', short: 'e' }),
     greeting: option({ type: string, long: 'greeting', short: 'g' }),
   },
-  handler: x => {
+  handler: (x) => {
     logMock('greeter', x);
   },
 });
@@ -27,7 +28,7 @@ const howdyPrinter = command({
   args: {
     name: positional({ type: string, displayName: 'name' }),
   },
-  handler: x => {
+  handler: (x) => {
     logMock('howdy', x);
   },
 });
@@ -43,16 +44,9 @@ const subcmds = subcommands({
 test('chooses one subcommand', async () => {
   const argv = `greeter Gal -eg Hello`.split(' ');
   const tokens = tokenize(argv);
-  const longOptionKeys = new Set<string>();
-  const shortOptionKeys = new Set<string>();
-  subcmds.register({
-    forceFlagLongNames: longOptionKeys,
-    forceFlagShortNames: shortOptionKeys,
-  });
-  const nodes = parse(tokens, {
-    longFlagKeys: longOptionKeys,
-    shortFlagKeys: shortOptionKeys,
-  });
+  const registerOptions = createRegisterOptions();
+  subcmds.register(registerOptions);
+  const nodes = parse(tokens, registerOptions);
   const result = await subcmds.parse({ nodes, visitedNodes: new Set() });
   const expected: typeof result = Result.ok({
     args: {
@@ -69,16 +63,9 @@ test('chooses one subcommand', async () => {
 test('chooses the other subcommand', async () => {
   const argv = `howdy joe`.split(' ');
   const tokens = tokenize(argv);
-  const longOptionKeys = new Set<string>();
-  const shortOptionKeys = new Set<string>();
-  subcmds.register({
-    forceFlagLongNames: longOptionKeys,
-    forceFlagShortNames: shortOptionKeys,
-  });
-  const nodes = parse(tokens, {
-    longFlagKeys: longOptionKeys,
-    shortFlagKeys: shortOptionKeys,
-  });
+  const registerOptions = createRegisterOptions();
+  subcmds.register(registerOptions);
+  const nodes = parse(tokens, registerOptions);
   const result = await subcmds.parse({ nodes, visitedNodes: new Set() });
   const expected: typeof result = Result.ok({
     command: 'howdy',
@@ -93,21 +80,14 @@ test('chooses the other subcommand', async () => {
 test('fails when using unknown subcommand', async () => {
   const argv = `--hello yes how are you joe`.split(' ');
   const tokens = tokenize(argv);
-  const longOptionKeys = new Set<string>();
-  const shortOptionKeys = new Set<string>();
-  subcmds.register({
-    forceFlagLongNames: longOptionKeys,
-    forceFlagShortNames: shortOptionKeys,
-  });
-  const nodes = parse(tokens, {
-    longFlagKeys: longOptionKeys,
-    shortFlagKeys: shortOptionKeys,
-  });
+  const registerOptions = createRegisterOptions();
+  subcmds.register(registerOptions);
+  const nodes = parse(tokens, registerOptions);
   const result = await subcmds.parse({ nodes, visitedNodes: new Set() });
   const expected: typeof result = Result.err({
     errors: [
       {
-        nodes: nodes.filter(x => x.raw === 'how'),
+        nodes: nodes.filter((x) => x.raw === 'how'),
         message: `Not a valid subcommand name`,
       },
     ],
@@ -120,21 +100,14 @@ test('fails when using unknown subcommand', async () => {
 test('fails for a subcommand argument parsing issue', async () => {
   const argv = `greeter Gal -g Hello --exclaim=hell-no`.split(' ');
   const tokens = tokenize(argv);
-  const longOptionKeys = new Set<string>();
-  const shortOptionKeys = new Set<string>();
-  subcmds.register({
-    forceFlagLongNames: longOptionKeys,
-    forceFlagShortNames: shortOptionKeys,
-  });
-  const nodes = parse(tokens, {
-    longFlagKeys: longOptionKeys,
-    shortFlagKeys: shortOptionKeys,
-  });
+  const registerOptions = createRegisterOptions();
+  subcmds.register(registerOptions);
+  const nodes = parse(tokens, registerOptions);
   const result = await subcmds.parse({ nodes, visitedNodes: new Set() });
   const expected = Result.err({
     errors: [
       {
-        nodes: nodes.filter(x => x.raw.includes('hell-no')),
+        nodes: nodes.filter((x) => x.raw.includes('hell-no')),
         message: `expected value to be either "true" or "false". got: "hell-no"`,
       },
     ],


### PR DESCRIPTION
Given `hello` as an option (which takes a string value),
The previous implementation would have been parsed the following input:

```bash
command --hello --world
```

into

```
{pos:command} {flag:hello} {flag:world}
```

The parser now registers options so it will force giving a value to
them. So the new parsed value would be:

```
{pos:command} {option:key=hello,value=--world}
```

This should support and fix #81
