### PR TITLE
Support rest parameters

### DIFF
--- a/example/rest-example.ts
+++ b/example/rest-example.ts
@@ -7,7 +7,7 @@ const cmd = command({
   },
   name: 'hi',
   handler({ scriptName, everythingElse }) {
-    console.log({ scriptName, everythingElse });
+    console.log(JSON.stringify({ scriptName, everythingElse }));
   },
 });
 

--- a/example/rest-example.ts
+++ b/example/rest-example.ts
@@ -1,0 +1,14 @@
+import { command, rest, binary, run, positional } from '../src';
+
+const cmd = command({
+  args: {
+    scriptName: positional(),
+    everythingElse: rest(),
+  },
+  name: 'hi',
+  handler({ scriptName, everythingElse }) {
+    console.log({ scriptName, everythingElse });
+  },
+});
+
+run(binary(cmd), process.argv);

--- a/src/command.ts
+++ b/src/command.ts
@@ -68,7 +68,7 @@ export function command<
     helpTopics() {
       return flatMap(
         Object.values(config.args).concat([circuitbreaker]),
-        x => x.helpTopics?.() ?? []
+        (x) => x.helpTopics?.() ?? []
       );
     },
     printHelp(context) {
@@ -90,7 +90,7 @@ export function command<
         lines.push(chalk.dim('> ') + config.description);
       }
 
-      const usageBreakdown = groupBy(this.helpTopics(), x => x.category);
+      const usageBreakdown = groupBy(this.helpTopics(), (x) => x.category);
 
       for (const [category, helpTopics] of entries(usageBreakdown)) {
         lines.push('');
@@ -175,8 +175,8 @@ export function command<
       }
     },
     async run(context) {
-      const parsed = await this.parse(context);
       const breaker = await circuitbreaker.parse(context);
+      const parsed = await this.parse(context);
       handleCircuitBreaker(context, this, breaker);
 
       if (Result.isErr(parsed)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,3 +18,4 @@ export { multiflag } from './multiflag';
 export { multioption } from './multioption';
 export { union } from './union';
 export { oneOf } from './oneOf';
+export { rest } from './rest';

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -1,0 +1,35 @@
+import type { ArgParser } from './argparser';
+import type { Descriptive, Displayed, ProvidesHelp } from './helpdoc';
+import * as Result from './Result';
+
+export function rest(
+  config?: Partial<Displayed & Descriptive>
+): ArgParser<string[]> & ProvidesHelp {
+  return {
+    helpTopics() {
+      const displayName = config?.displayName ?? 'arg';
+      return [
+        {
+          usage: `[...${displayName}]`,
+          category: 'arguments',
+          defaults: [],
+          description: config?.description ?? 'catches the rest of the values',
+        },
+      ];
+    },
+    register() {},
+    async parse(context) {
+      const visitedNodeIndices = [...context.visitedNodes]
+        .map((x) => context.nodes.indexOf(x))
+        .filter((x) => x > -1);
+      if (visitedNodeIndices.length === 0) {
+        return Result.ok([]);
+      }
+
+      const maxIndex = Math.max(...visitedNodeIndices);
+      const restItems = context.nodes.slice(maxIndex + 1);
+      restItems.forEach((node) => context.visitedNodes.add(node));
+      return Result.ok(restItems.map((x) => x.raw));
+    },
+  };
+}

--- a/test/rest-parameters.test.ts
+++ b/test/rest-parameters.test.ts
@@ -1,0 +1,26 @@
+import path from 'path';
+import { app } from './util';
+
+const runAppRestExample = app(
+  path.join(__dirname, '../example/rest-example.ts')
+);
+
+it('should be able to use rest parameters after the positional', async () => {
+  const result = await runAppRestExample([
+    'pos',
+    'more',
+    '--rest',
+    'parameters',
+  ]);
+  expect(JSON.parse(result.stdout)).toEqual({
+    scriptName: 'pos',
+    everythingElse: ['more', '--rest parameters'],
+    //                       ^ this is weird, but it's the way it is.
+  });
+});
+
+it('should fail if the positional is not provided', async () => {
+  const result = await runAppRestExample(['--rest', 'parameters']);
+  expect(result.exitCode).toBe(1);
+  expect(result.stderr).toContain('No value provided for str');
+});

--- a/test/ui.test.ts
+++ b/test/ui.test.ts
@@ -1,5 +1,5 @@
-import execa, { ExecaReturnValue } from 'execa';
 import path from 'path';
+import { app } from './util';
 
 test('help for subcommands', async () => {
   const result = await runApp1(['--help']);
@@ -97,23 +97,3 @@ test('subcommands with process.argv.slice(2)', async () => {
 const runApp1 = app(path.join(__dirname, '../example/app.ts'));
 const runApp2 = app(path.join(__dirname, '../example/app2.ts'));
 const runApp3 = app(path.join(__dirname, '../example/app3.ts'));
-
-function app(
-  scriptPath: string
-): (args: string[]) => Promise<ExecaReturnValue> {
-  return async (args) => {
-    jest.setTimeout(10000);
-    const result = await execa(
-      path.join(__dirname, '../scripts/ts-node'),
-      [scriptPath, ...args],
-      {
-        all: true,
-        reject: false,
-        env: {
-          FORCE_COLOR: 'true',
-        },
-      }
-    );
-    return result;
-  };
-}

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,0 +1,22 @@
+import execa, { ExecaReturnValue } from 'execa';
+import path from 'path';
+
+export function app(
+  scriptPath: string
+): (args: string[]) => Promise<ExecaReturnValue> {
+  return async (args) => {
+    jest.setTimeout(10000);
+    const result = await execa(
+      path.join(__dirname, '../scripts/ts-node'),
+      [scriptPath, ...args],
+      {
+        all: true,
+        reject: false,
+        env: {
+          FORCE_COLOR: 'true',
+        },
+      }
+    );
+    return result;
+  };
+}


### PR DESCRIPTION
allow the ability to catch all the arguments, not just positional.
This will allow having a CLI that works like so:

    fnm exec --using=12 node -v
                           ^^ - positional argument, can be forwarded

instead of:

    fnm exec --using=12 -- node -v

The problem is that with the current implementation of the parser,
options and circuitbreakers look "everywhere" within the node array
so the following:

    fnm exec --using=12 node --help

will be the same as:

    fnm exec --help --using=12 node

Eventually this needs to be taken care of. A flag can be global, but
the default behavior should be local to the declaration. CLI commands
form a tree and we need to make sure we don't have global searches
by default.
