### PR TITLE
add parse method to runner

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export { command } from './command';
 export { flag } from './flag';
 export { option } from './option';
 export { positional } from './positional';
-export { dryRun, runSafely, run, Runner } from './runner';
+export { dryRun, runSafely, run, parse, Runner } from './runner';
 export { restPositionals } from './restPositionals';
 export { multiflag } from './multiflag';
 export { multioption } from './multioption';


### PR DESCRIPTION
Hey @Schniz,

I really like your package. You've created the best argument parser in the typescript world, IMO.

However, sometimes it is necessary to be able to use runtime objects after parsing, which aren't available during command creation. 

I've got this lovely command here, but if my `client` for some third party service gets created at a later point, I can't use the `client` in the command handler.

```
import * as cmd from 'cmd-ts';

const someCommand = cmd.command({
  name: 'some-command',
  args: {
    someArg: cmd.positional({ type: cmd.string }),
    someAmount: cmd.option({ type: cmd.number, long: 'amount', short: 'a', defaultValue: () => 1}),
  },
  handler: async ({ someArg, someAmount }) => {
    console.log(`some-command ${someArg} ${someAmount}`);
    // no access to client
  },
});

const client = new ThirdPartyService(apiKey);
```

In general, it would be extremely useful if it was possible to use your package to handle typesafe command registration and parsing, and retrieve the parse result directly, instead of only being able to pipe it through the handler.

This PR exposes exactly this functionality, via a `parse` function on the runner. Would you consider merging and supporting this functionality? There is really no alternative for this kind of thing. Using `io-ts` directly in each project would be a pain and would require recreating a ton of the work you already did.

Another option would be to give the runner the ability to overload the handler when `run` is called, as opposed to only being able to supply it when the command is created.