### PR TITLE
Default to help when calling subcommands without any arguments

### DIFF
--- a/.changeset/proud-buses-fly.md
+++ b/.changeset/proud-buses-fly.md
@@ -1,0 +1,5 @@
+---
+'cmd-ts': minor
+---
+
+Display help when calling subcommands without any arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # cmd-ts
 
+## 0.12.0
+
+### Major Changes
+
+- 2c340fd: Display help when calling subcommands without any arguments.
+
 ## 0.11.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # cmd-ts
 
-## 0.12.0
-
-### Major Changes
-
-- 2c340fd: Display help when calling subcommands without any arguments.
-
 ## 0.11.0
 
 ### Minor Changes

--- a/src/subcommands.ts
+++ b/src/subcommands.ts
@@ -79,6 +79,22 @@ export function subcommands<
     type,
   });
 
+  function normalizeContext(context: ParseContext) {
+    if (context.hotPath?.length === 0) {
+      context.hotPath.push(config.name);
+    }
+
+    // Called without any arguments? We default to subcommand help.
+    if (!context.nodes.some((n) => !context.visitedNodes.has(n))) {
+      context.nodes.push({
+        type: 'longOption',
+        index: 0,
+        key: 'help',
+        raw: '--help',
+      });
+    }
+  }
+
   return {
     version: config.version,
     description: config.description,
@@ -129,9 +145,7 @@ export function subcommands<
     async parse(
       context: ParseContext
     ): Promise<ParsingResult<Output<Commands>>> {
-      if (context.hotPath?.length === 0) {
-        context.hotPath.push(config.name);
-      }
+      normalizeContext(context);
       const parsed = await subcommand.parse(context);
 
       if (Result.isErr(parsed)) {
@@ -160,10 +174,7 @@ export function subcommands<
       });
     },
     async run(context): Promise<ParsingResult<RunnerOutput<Commands>>> {
-      if (context.hotPath?.length === 0) {
-        context.hotPath.push(config.name);
-      }
-
+      normalizeContext(context);
       const parsedSubcommand = await subcommand.parse(context);
 
       if (Result.isErr(parsedSubcommand)) {

--- a/test/__snapshots__/ui.test.ts.snap
+++ b/test/__snapshots__/ui.test.ts.snap
@@ -48,6 +48,31 @@ Along with the following error:
 [31m[1mhint: [22m[39mfor more information, try '[33msubcmds greet --help[39m'"
 `;
 
+exports[`displays nested subcommand help if no arguments passed 1`] = `
+"[1msubcmds composed[3m <subcommand>[23m[22m
+[2m> [22ma nested subcommand
+
+where [3m<subcommand>[23m can be one of:
+
+[2m- [22mcat - A simple \`cat\` clone [2m[alias: read][22m
+
+[2mFor more help, try running \`[33msubcmds composed <subcommand> --help[39m\`[22m"
+`;
+
+exports[`displays subcommand help if no arguments passed 1`] = `
+"[1msubcmds[3m <subcommand>[23m[22m
+[2m> [22mAn awesome subcommand app!
+
+where [3m<subcommand>[23m can be one of:
+
+[2m- [22mcomplex - Just prints the arguments
+[2m- [22mcat - A simple \`cat\` clone [2m[alias: read][22m
+[2m- [22mgreet - greet a person
+[2m- [22mcomposed - a nested subcommand
+
+[2mFor more help, try running \`[33msubcmds <subcommand> --help[39m\`[22m"
+`;
+
 exports[`failures in defaultValue 1`] = `
 "[31m[1merror: [22m[39mfound [33m3[39m errors
 

--- a/test/ui.test.ts
+++ b/test/ui.test.ts
@@ -37,6 +37,18 @@ test('suggests a subcommand on typo', async () => {
   expect(result.exitCode).toBe(1);
 });
 
+test('displays subcommand help if no arguments passed', async () => {
+  const result = await runApp1([]);
+  expect(result.all).toMatchSnapshot();
+  expect(result.exitCode).toBe(1);
+});
+
+test('displays nested subcommand help if no arguments passed', async () => {
+  const result = await runApp1(['composed']);
+  expect(result.all).toMatchSnapshot();
+  expect(result.exitCode).toBe(1);
+});
+
 test('composes errors', async () => {
   const result = await runApp1([
     'greet',


### PR DESCRIPTION
This improves output when calling subcommand-based tools by displaying subcommand help (rather than "No value provided for subcommand"); and works with nested subcommands.

This fixes #177