### PR TITLE
Allow readonly T[] in oneOf

### DIFF
--- a/.changeset/dull-penguins-explode.md
+++ b/.changeset/dull-penguins-explode.md
@@ -1,0 +1,5 @@
+---
+"cmd-ts": patch
+---
+
+Allow readonly T[] in oneOf

--- a/src/oneOf.ts
+++ b/src/oneOf.ts
@@ -4,7 +4,7 @@ import { inspect } from 'util';
 /**
  * A union of literals. When you want to take an exact enum value.
  */
-export function oneOf<T extends string>(literals: T[]): Type<string, T> {
+export function oneOf<T extends string>(literals: readonly T[]): Type<string, T> {
   const examples = literals.map(x => inspect(x)).join(', ');
   return {
     async from(str) {


### PR DESCRIPTION
`readonly T[]` is a subset of `T[]`

Ideally we could do this:

```ts
import * as cmd from 'cmd-ts';

const options = ['a', 'b', 'c'] as const;

const option = cmd.oneOf(options);
```

https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAKjgQwM5wMYgCZwGZQQhwDkW2AtDKiQNwCwAUExhAHarwRgzDvoBeOAG0SyEgBpSAI0mkMJALop0rDjAbNGaznG692cIeQB07AKYB5PAAp9fDgEpaQA

One workaround is using `.slice()` to turn it into a non-readonly array