### PR TITLE
flag: fix defaultValue bug

### DIFF
--- a/.changeset/violet-numbers-glow.md
+++ b/.changeset/violet-numbers-glow.md
@@ -1,0 +1,5 @@
+---
+"cmd-ts": patch
+---
+
+flag: respect defaultValue in `flag`

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -112,16 +112,17 @@ export function fullFlag<Decoder extends Type<boolean, any>>(
       const valueFromEnv = config.env ? process.env[config.env] : undefined;
       let rawValue: string;
       let envPrefix = '';
+      const defaultValueFn = config.defaultValue ?? config.type.defaultValue;
 
       if (options.length === 0 && valueFromEnv !== undefined) {
         rawValue = valueFromEnv;
         envPrefix = `env[${chalk.italic(config.env)}]: `;
       } else if (
         options.length === 0 &&
-        typeof config.type.defaultValue === 'function'
+        typeof defaultValueFn === 'function'
       ) {
         try {
-          return Result.ok(config.type.defaultValue());
+          return Result.ok(defaultValueFn());
         } catch (e: any) {
           const message = `Default value not found for '--${config.long}': ${e.message}`;
           return Result.err({


### PR DESCRIPTION
Right now, it ignores a default value set in FlagConfig and only uses the one set by the `type` field.

(I basically mirrored the code from `option.ts`)