### PR TITLE
fix: exit --help with code 0

### DIFF
--- a/src/circuitbreaker.ts
+++ b/src/circuitbreaker.ts
@@ -32,7 +32,7 @@ export function handleCircuitBreaker(
 
   if (breaker.value === 'help') {
     const message = value.printHelp(context);
-    throw new Exit({ exitCode: 1, message, into: 'stdout' });
+    throw new Exit({ exitCode: 0, message, into: 'stdout' });
   } else if (breaker.value === 'version') {
     const message = value.version || '0.0.0';
     throw new Exit({ exitCode: 0, message, into: 'stdout' });


### PR DESCRIPTION
Fixes #80. Not sure why `--help` exits with an error code (1) but this just changes that to exit code 0.