### PR TITLE
Fix docs link for args in command parser

### DIFF
--- a/docs/parsers/command.md
+++ b/docs/parsers/command.md
@@ -7,7 +7,7 @@ This is what we call "a combinator": `command` takes multiple parsers and combin
 - `name` (required): A name for the command
 - `version`: A version for the command
 - `handler` (required): A function that takes all the arguments and do something with it
-- `args` (required): An object where the keys are the argument names (how they'll be treated in code) and the values are [parsers](../paresrs.md)
+- `args` (required): An object where the keys are the argument names (how they'll be treated in code) and the values are [parsers](../parsers.md)
 - `aliases`: A list of other names this command can be called with. Useful with [`subcommands`](./subcommands.md)
 
 ### Usage


### PR DESCRIPTION
## Summary
- fix link for `args` in command parser docs

## Testing
- `yarn test` *(fails: Can not find dependency 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_68434cc7db0c832b902f7a840c1b5278